### PR TITLE
Negative votes - bug fix

### DIFF
--- a/pages/vote.js
+++ b/pages/vote.js
@@ -88,8 +88,9 @@ function Vote({ query }) {
    * @param {boolean} increment -/+ button toggle
    */
   const calculateShow = (current, increment) => {
+    const change = increment ? 1 : -1;
     const canOccur =
-      Math.abs(Math.pow(current, 2) - Math.pow(current + 1, 2)) <= credits;
+      Math.abs(Math.pow(current, 2) - Math.pow(current + change, 2)) <= credits;
     // Check for absolute squared value of current - absolute squared valueof current + 1 <= credits
 
     // If current votes === 0, and available credits === 0


### PR DESCRIPTION
The vote function doesn't handle negative votes correctly, in particular, the piece that checks "can the voter add a vote to this proposal," is flawed.

If x = number of votes allocated to a proposal, the function checks if x^2 - (x + 1)^2 <= number of credits remaining. 

So if you're adding negative votes, x + 1 is going in the wrong direction.

This patch fixes the negative vote bug.