### PR TITLE
Fix timing attack vulnerability for admin secret

### DIFF
--- a/pages/api/events/details.js
+++ b/pages/api/events/details.js
@@ -1,4 +1,5 @@
 import prisma from "db"; // Import prisma
+import { timingSafeEqual } from "crypto";
 
 // --> /api/events/details
 export default async (req, res) => {
@@ -17,9 +18,14 @@ export default async (req, res) => {
     where: { event_uuid: id },
   });
 
-  // Check for administrator access based on passed secret_key
+  // Check for administrator access based on passed secret_key with node.js'
+  // crypto `timingSafeEqual` to prevent timing attacks.
   const isAdmin =
-    event.secret_key && event.secret_key === secret_key ? true : false;
+    event.secret_key &&
+    secret_key &&
+    event.secret_key.length === secret_key.length &&
+    timingSafeEqual(Buffer.from(event.secret_key), Buffer.from(secret_key));
+
   // After checking for administrator access, delete secret_key from event object
   delete event.secret_key;
 


### PR DESCRIPTION
Direct comparisons of strings in node.js should be avoided given that an
attacker could brute force their way to the key, given a timing attack
strategy. The node.js docs recommend using `timingSafeEqual` from the
`crypto` standard lib.

fixes #10 