### PR TITLE
Stop label skipping on yAxis with chartjs option

### DIFF
--- a/pages/event.js
+++ b/pages/event.js
@@ -147,7 +147,13 @@ function Event({ query }) {
           <p>Quadratic Voting-weighted voting results</p>
           {!loading && data ? (
             <div className="chart">
-              <HorizontalBar data={data.chart} width={50} />
+              <HorizontalBar
+                data={data.chart}
+                width={50}
+                options={{
+                  scales: { yAxes: [{ ticks: { autoSkip: false } }] }
+                }}
+              />
             </div>
           ) : (
             <div className="loading__chart">


### PR DESCRIPTION
fixes #12 

I have not tested this fix as I didn't have time to set up a PostgreSQL myself yet. Please feel free to close if this doesn't address the issue. I just read around chartjs docs and found `autoskip`

reference:

- https://www.chartjs.org/docs/latest/axes/cartesian/_common_ticks.html#common-tick-options-to-all-cartesian-axes